### PR TITLE
Fixes #58 - Update VFPC sid.json

### DIFF
--- a/OBBB/Plugins/VFPC/Sid.json
+++ b/OBBB/Plugins/VFPC/Sid.json
@@ -8,7 +8,6 @@
                "max_fl": 260,
                "destinations": [
                   "OKKK"
-
                ],
                "airways": [
                   "A453"
@@ -28,7 +27,6 @@
                "max_fl": 330,
                "destinations": [
                   "OOMS"
-
                ],
                "airways": [
                   "N697"
@@ -38,14 +36,7 @@
                "direction": "ODD",
                "max_fl": 250,
                "destinations": [
-                  "OMAA",
-                  "OMAD",
-                  "OMAL",
-                  "OMDB",
-                  "OMDW",
-                  "OMRK",
-                  "OMSJ"
-
+                  "OM"
                ],
                "airways": [
                   "N318",
@@ -57,7 +48,6 @@
                "max_fl": 230,
                "destinations": [
                   "OOSH"
-
                ],
                "airways": [
                   "N685"
@@ -67,9 +57,7 @@
                "direction": "ODD",
                "max_fl": 110,
                "destinations": [
-                  "OTHH",
-                  "OTBD"
-
+                  "OT"
                ],
                "airways": [
                   "N318"
@@ -81,6 +69,13 @@
                   "L319",
                   "N318",
                   "N697"
+               ]
+            },
+            {
+               "direction": "EVEN"
+               "max_fl": "60",
+               "destinations": [
+                  "OEDF"
                ]
             }
          ]


### PR DESCRIPTION
Fixes #58

Better matching of flight level capping. Changed to partial 'OM' detection instead of multiple specified aerodromes.

Added OEDF 6000' level cap.

Cleaned up file to remove redundant paragraph lines